### PR TITLE
Avoid unwanted globbing and wordsplitting

### DIFF
--- a/wesnoth-love
+++ b/wesnoth-love
@@ -5,5 +5,5 @@
 ## SPDX-License-Identifier: GPL-2.0+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $DIR
-love ./ $@
+cd "$DIR" || exit
+love ./ "$@"


### PR DESCRIPTION
Avoids issues with whitespace or globbing characters in the install path or the passed arguments. Also aborts if the cd fails for some reason.